### PR TITLE
Fix for PropTypes warning in React 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "co": ">=4.6.0",
     "react": ">=0.14.0",
-    "oidc-client": ">=1.2.0"
-	"prop-types": ">=15.5.0",
+    "oidc-client": ">=1.2.0",
+	"prop-types": ">=15.5.0"
   },
   "optionalDependencies": {
     "immutable": ">=3.6.0"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "co": ">=4.6.0",
     "react": ">=0.14.0",
     "oidc-client": ">=1.2.0"
+	"prop-types": ">=15.5.0",
   },
   "optionalDependencies": {
     "immutable": ">=3.6.0"

--- a/src/CallbackComponent.js
+++ b/src/CallbackComponent.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { redirectSuccess } from './actions';
 
 class CallbackComponent extends React.Component {

--- a/src/OidcProvider.js
+++ b/src/OidcProvider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { userExpired, userFound, silentRenewError, sessionTerminated, userExpiring, userSignedOut } from './actions';
 
 class OidcProvider extends React.Component {


### PR DESCRIPTION
Fixes: "Warning: Accessing PropTypes via the main React package is
deprecated. Use the prop-types package from npm instead."