### PR TITLE
Corrected typing.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module 'redux-oidc' {
     import * as React from 'react';
 
     export interface UserState {
-        user: User;
+        user?: User;
         isLoadingUser: boolean;
     }
 


### PR DESCRIPTION
The `UserState` did not match the initial state found in https://github.com/maxmantz/redux-oidc/blob/master/src/reducer/reducer.js#L12 . the `user `property` should be nullable.