### PR TITLE
Immutable reducer should deeply convert non-object user payload

### DIFF
--- a/src/reducer/reducer-immutable.js
+++ b/src/reducer/reducer-immutable.js
@@ -15,10 +15,10 @@ try {
   const { fromJS, Seq } = require('immutable');
 
   const fromJSGreedy = (js) => {
-      return typeof js !== 'object' || js === null ? js :
-          Array.isArray(js) ?
-          Seq(js).map(fromJSGreedy).toList() :
-          Seq(js).map(fromJSGreedy).toMap();
+    return typeof js !== 'object' || js === null ? js :
+      Array.isArray(js) ?
+      Seq(js).map(fromJSGreedy).toList() :
+      Seq(js).map(fromJSGreedy).toMap();
   }
 
   const initialState = fromJS({

--- a/src/reducer/reducer-immutable.js
+++ b/src/reducer/reducer-immutable.js
@@ -12,7 +12,14 @@ import {
 let reducer;
 
 try {
-  const fromJS = require('immutable').fromJS;
+  const { fromJS, Seq } = require('immutable');
+
+  const fromJSGreedy = (js) => {
+      return typeof js !== 'object' || js === null ? js :
+          Array.isArray(js) ?
+          Seq(js).map(fromJSGreedy).toList() :
+          Seq(js).map(fromJSGreedy).toMap();
+  }
 
   const initialState = fromJS({
     user: null,
@@ -39,7 +46,7 @@ try {
         });
       case REDIRECT_SUCCESS:
       case USER_FOUND:
-        return fromJS({
+        return fromJSGreedy({
           user: action.payload,
           isLoadingUser: false
         });

--- a/tests/reducer/reducer-immutable.test.js
+++ b/tests/reducer/reducer-immutable.test.js
@@ -64,6 +64,20 @@ describe('immutable reducer', () => {
     expect(reducer(fromJS(initialState), userFound(user))).toEqual(expectedResult);
   });
 
+  it('should handle USER_FOUND correctly when payload has non-object prototype', () => {
+      function NonObject() {
+        this.type = 'not-an-object'
+      }
+      const user = { some: 'user' };
+      const nonObjectUser = Object.setPrototypeOf({ some: 'user' }, new NonObject());
+      const expectedResult = fromJS({
+          user,
+          isLoadingUser: false
+      });
+
+      expect(reducer(fromJS(initialState), userFound(nonObjectUser))).toEqual(expectedResult);
+  });
+
   it('should handle SESSION_TERMINATED correctly', () => {
     const expectedResult = fromJS({
       user: null,


### PR DESCRIPTION
Hi @maxmantz,

Thanks for an amazingly useful lib!

Currently, the Immutable Reducer does not deeply convert the `action.payload` to Immutable structures because `fromJS` does not deeply convert "maps" with non-`Object` prototype. This is awkward for many immutable-js / redux users because we try to follow [never mix plain and immutable objects](http://redux.js.org/docs/recipes/UsingImmutableJS.html#never-mix-plain-javascript-objects-with-immutablejs).

This PR adds `fromJSGreedy` from this [immutable example](https://github.com/facebook/immutable-js/wiki/Converting-from-JS-objects) so that the entire `oidc` tree is immutable datastructures.

I realize this is a breaking change for Immutable Reducer users, and as such is sensitive; however, I do think it's the best path forward. Please let me know if you have any questions.

Cheers,

Adam

