### PR TITLE
Added a state argument for CallbackComponent and OidcProvder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,14 +25,14 @@ declare module 'redux-oidc' {
         readonly route?: string;
     }
 
-    export class CallbackComponent extends React.Component<CallbackComponentProps> { }
+    export class CallbackComponent extends React.Component<CallbackComponentProps, void> { }
 
     export interface OidcProviderProps<TSTate> {
         readonly userManager: UserManager;
         readonly store: Store<TSTate>;
     }
 
-    export class OidcProvider<TState> extends React.Component<OidcProviderProps<TState>> { }
+    export class OidcProvider<TState> extends React.Component<OidcProviderProps<TState>, void> { }
 
     // Components
     export function createUserManager(options: UserManagerSettings): UserManager;


### PR DESCRIPTION
This should fix the bug where typescript needs 2 arguments (props and state) for using this components