### PR TITLE
Update oidc-client to 1.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "react": ">=0.15.0",
     "prop-types": ">=15.5.0",
-    "oidc-client": "^1.4.1"
+    "oidc-client": "^1.5.4"
   },
   "optionalDependencies": {
     "immutable": ">=3.6.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "react": ">=0.15.0",
-    "prop-types": ">=15.5.0",
+    "prop-types": ">=15.5.8",
     "oidc-client": "^1.5.4"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Updates the minimum version of `oidc-client` to `1.5.4`. 

Tested using the `redux-oidc-sample` project with build-output from this project.