### PR TITLE
Add `null` as a valid value for the `UserState.user`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ declare module "redux-oidc" {
   }
 
   export interface UserState {
-    readonly user?: User;
+    readonly user?: User | null;
     readonly isLoadingUser: boolean;
   }
 


### PR DESCRIPTION
The actions set the `user` object to `null` on the state but the typings on `UserState` do not allow that value, just `undefined`